### PR TITLE
Fix payload to session update

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "order-configuration",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "title": "Order Configuration",
   "description": "A custom price selector for B2B users",
   "defaultLocale": "pt-BR",

--- a/react/components/FormHandler.tsx
+++ b/react/components/FormHandler.tsx
@@ -43,7 +43,7 @@ export const FormHandler: FC<{
 
       await updateCustomSessionKeyMutation({
         variables: {
-          sessionData: { sessionData: { ...data, email: props.email } },
+          sessionData: { sessionData: { ...data } },
         },
       })
         .then(async () => {


### PR DESCRIPTION
#### What problem is this solving?

The price simulator app is not prepared to receive email in`customSessionKeys`. As it is already being passed in the `profile` section of the session, it is ok to remove it.

#### How should this be manually tested?

Access `cpqdemo--b2bstore.myvtex.com`, change order configuration, check-in `cpqdemo--b2bstore.myvtex.com/api/sessions?items=*` if the email is no more passed in `customSessionKeys`.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
