### PR TITLE
feat: turning title clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [3.1.0] - 2021-06-09
 ### Added
 - Turning title inside header clickable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Turning title inside header clickable
+- Adding CSS Handle to form group object
 
 ## [3.1.0] - 2020-12-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.1.0] - 2021-06-09
+### Added
+- Turning title inside header clickable
+
 ## [3.1.0] - 2020-12-09
 
 ## [3.0.0] - 2020-12-09

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 📢 Use this project, [contribute](https://github.com/vtex-apps/order-configuration) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).
 
-# Order Configuration 
+# Order Configuration
 
 <!-- DOCS-IGNORE:start -->
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
@@ -8,12 +8,12 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 <!-- DOCS-IGNORE:end -->
 
-The Order Configuration app, designed for **B2B scenarios**, displays a form responsible for collecting order data in a modal. 
+The Order Configuration app, designed for **B2B scenarios**, displays a form responsible for collecting order data in a modal.
 
 ![order-configuration-gif](https://user-images.githubusercontent.com/52087100/91925199-e5125200-ecaa-11ea-8734-f98921ddb384.gif)
 
 
-Once the form is submitted, the order data collected will be available at MasterData and saved in the current VTEX session. 
+Once the form is submitted, the order data collected will be available at MasterData and saved in the current VTEX session.
 
 :information_source: *This app can be used to customize all kinds of behaviours, such as custom prices, custom products, etc. Keep in mind that this app does not offer such functionality, but enables these other apps to do so.*
 
@@ -168,7 +168,7 @@ Refer to [MasterData documentation](https://developers.vtex.com/vtex-developer-d
 
 ### Advanced configuration
 
-If desired, you can declare the `order-config.form` block by adding and configuring the `formFields` prop and an array of form children blocks (whose descriptions you can find below). 
+If desired, you can declare the `order-config.form` block by adding and configuring the `formFields` prop and an array of form children blocks (whose descriptions you can find below).
 
 ```json
 {
@@ -270,21 +270,21 @@ If desired, you can declare the `order-config.form` block by adding and configur
 | `order-config.submit` | Renders a `Submit` button. |
 | `order-config.dropdown` | Renders the a dropdown field. |
 | `order-config.radiogroup` | Renders a radiogroup field. |
-| `order-config.text` | Renders a text field. | 
-| `order-config.textarea` | Renders a text field with a wider range of available characters. | 
-| `order-config.checkbox` | Renders a checkbox field. | 
+| `order-config.text` | Renders a text field. |
+| `order-config.textarea` | Renders a text field with a wider range of available characters. |
+| `order-config.checkbox` | Renders a checkbox field. |
 
 ### `order-config.dropdown`, `order-config.radiogroup`, `order-config.text`, `order-config.textarea`, and `order-config.checkbox` prop
 
 | Prop name | Type | Description  | Default Value |
 | --------- | -------- | ------------| ----------------- |
-| `pointer`  | `string` | Path to which the block must point in the `formFields` prop in order to properly work.  | `undefined`              | 
+| `pointer`  | `string` | Path to which the block must point in the `formFields` prop in order to properly work.  | `undefined`              |
 
 ### `order-config.form` prop
 
 | Prop name | Type | Description  | Default Value |
 | --------- | -------- | ------------| ----------------- |
-| `formFields`  | `object` | Object responsible for defining the form fields.  | `undefined`              | 
+| `formFields`  | `object` | Object responsible for defining the form fields.  | `undefined`              |
 
 - **`formFields` object:**
 
@@ -309,17 +309,18 @@ If desired, you can declare the `order-config.form` block by adding and configur
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
 | CSS Handles |
-| ----------- | 
+| ----------- |
 | `formSubmitButton` |
 | `formSubmitContainer` |
 | `formErrorServer` |
 | `formErrorUserInput` |
-| `loader` | 
+| `loader` |
 | `orderConfigFormWrapper` |
-| `title` | 
+| `formObject` |
+| `title` |
 | `titleValues` |
 | `titleWrapper` |
-| `wrapper` | 
+| `wrapper` |
 
 <!-- DOCS-IGNORE:start -->
 ## Contributors ✨

--- a/react/Title.tsx
+++ b/react/Title.tsx
@@ -1,8 +1,10 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { filter, pick, values } from 'ramda'
 import { useCssHandles } from 'vtex.css-handles'
-import { useOrderConfiguration } from './OrderConfigurationContext'
-
+import {
+  useOrderConfigurationDispatch,
+  useOrderConfiguration,
+} from './OrderConfigurationContext'
 const CSS_HANDLES = ['title', 'titleValues', 'titleWrapper'] as const
 
 const Title: StorefrontFunctionComponent<{
@@ -10,9 +12,18 @@ const Title: StorefrontFunctionComponent<{
 }> = props => {
   const handles = useCssHandles(CSS_HANDLES)
   const { selectedValues, formFields } = useOrderConfiguration()
+  const dispatch = useOrderConfigurationDispatch()
   const { formTitle } = props
+  const onModalOpen = useCallback(() => {
+    dispatch({ type: 'SET_MODAL_OPEN', args: { isModalOpen: true } })
+  }, [dispatch])
+
   return (
-    <div className={`flex items-center ${handles.titleWrapper}`}>
+    <div
+      onClick={onModalOpen}
+      aria-hidden="true"
+      className={`flex items-center ${handles.titleWrapper}`}
+    >
       <span className={`mr4 ${handles.title}`}>{formTitle}</span>
       <span className={`mr4 fw6 ${handles.titleValues}`}>
         {values(

--- a/react/Title.tsx
+++ b/react/Title.tsx
@@ -22,7 +22,7 @@ const Title: StorefrontFunctionComponent<{
     <div
       onClick={onModalOpen}
       aria-hidden="true"
-      className={`flex items-center ${handles.titleWrapper}`}
+      className={`flex items-center shadow-hover ${handles.titleWrapper}`}
     >
       <span className={`mr4 ${handles.title}`}>{formTitle}</span>
       <span className={`mr4 fw6 ${handles.titleValues}`}>

--- a/react/components/Object.tsx
+++ b/react/components/Object.tsx
@@ -9,7 +9,7 @@ import {
   UseTextAreaReturnType,
   UseCheckboxReturnType,
 } from 'react-hook-form-jsonschema'
-
+import { useCssHandles } from 'vtex.css-handles'
 import { Input } from './Input'
 import { TextArea } from './TextArea'
 import { RadioGroup } from './RadioGroup'
@@ -17,6 +17,8 @@ import { Dropdown } from './Dropdown'
 import { Checkbox } from './Checkbox'
 import { FormFieldGroupProps } from '../typings/InputProps'
 import { FormField } from '../typings/FormProps'
+
+const CSS_HANDLES = ['formObject'] as const
 
 const SpecializedObject: FC<{
   baseObject: InputReturnTypes
@@ -67,11 +69,15 @@ export const ObjectMapper: FC<FormFieldGroupProps> = props => {
     pointer,
     UISchema: uiSchema,
   })
+  const handles = useCssHandles(CSS_HANDLES)
 
   return (
     <>
       {methods.map(obj => (
-        <div className="pa5" key={`${obj.type}${obj.pointer}`}>
+        <div
+          className={`pa5 ${handles.formObject}`}
+          key={`${obj.type}${obj.pointer}`}
+        >
           <SpecializedObject
             baseObject={obj}
             formFields={formFields}


### PR DESCRIPTION
#### What problem is this solving?

Turning order configuration title's clickable

#### How should this be manually tested?

1 - Login in https://luizdev3--b2bstore.myvtex.com/

2 - Click in order configuration title at header right side. (It must be opened)


#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

Click on title to open the modal
![image](https://user-images.githubusercontent.com/71646769/121359675-18ed6880-c90a-11eb-92f4-0ab61420a9b3.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
